### PR TITLE
update snapshot generator templates - remove labels

### DIFF
--- a/tools/snapshot-generator/templates/stage/component_snapshot.yaml
+++ b/tools/snapshot-generator/templates/stage/component_snapshot.yaml
@@ -3,10 +3,6 @@ kind: Snapshot
 metadata:
   name: {{component_application}}-{{epoch}}
   namespace: rhoai-tenant
-  labels:
-#    test.appstudio.openshift.io/type: override
-    konflux-release-data/rbc-release-commit: {{rbc_release_commit}}
-    konflux-release-data/artifact-type: components
 spec:
   application: {{component_application}}
   components: []

--- a/tools/snapshot-generator/templates/stage/fbc_snapshot.yaml
+++ b/tools/snapshot-generator/templates/stage/fbc_snapshot.yaml
@@ -3,11 +3,6 @@ kind: Snapshot
 metadata:
   name: {{fbc_component}}-{{epoch}}
   namespace: rhoai-tenant
-  labels:
-#    test.appstudio.openshift.io/type: override
-    konflux-release-data/rbc-release-commit: {{rbc_release_commit}}
-    konflux-release-data/ocp-version: {{ocp-version}}
-    konflux-release-data/artifact-type: fbc
 spec:
   application: {{rhoai_application}}
   components:


### PR DESCRIPTION
the presence of konflux release labels was causing issues/conflicts during release.